### PR TITLE
feat(workshops): wider responsive layout for workshop list

### DIFF
--- a/frontend/src/app/workshops/page.tsx
+++ b/frontend/src/app/workshops/page.tsx
@@ -36,7 +36,7 @@ export default function Workshops() {
         </p>
       </div>
 
-      <div className="max-w-4xl mx-auto px-6 py-14 flex flex-col gap-12">
+      <div className="w-full max-w-6xl mx-auto px-4 sm:px-6 lg:px-10 py-14 flex flex-col gap-12">
         <UpcomingWorkshops upcomingWorkshops={upcomingWorkshops} />
         <PastWorkshops pastWorkshops={pastWorkshops} />
       </div>

--- a/frontend/src/components/PageSection.tsx
+++ b/frontend/src/components/PageSection.tsx
@@ -38,8 +38,8 @@ function PageSectionInner(props: {
   return (
     <Box
       className={
-        "px-8 md:w-8/12 max-w-7xl flex flex-col justify-center" +
-        (props.className ?? "")
+        "w-full max-w-7xl flex flex-col justify-center" +
+        (props.className ? " " + props.className : "")
       }
       sx={props.sx}
     >

--- a/frontend/src/components/WorkshopAccordion.tsx
+++ b/frontend/src/components/WorkshopAccordion.tsx
@@ -75,59 +75,62 @@ export function WorkshopAccordion(props: {
           >
             <AccordionSummary
               expandIcon={
-                <div className="flex flex-row items-center">
+                <div className="flex flex-row items-center shrink-0">
                   <ExpandMoreOutlined />
                 </div>
               }
-              className="p-0 m-0"
+              className="p-0 m-0 w-full"
+              sx={{ "& .MuiAccordionSummary-content": { width: "100%", minWidth: 0 } }}
             >
-              <Box
-                component="img"
-                src={`https://factorystrapi.mcgilleus.ca${workshop.attributes.CoverPicture.data[0].attributes.url}`}
-                className="h-24 w-24 rounded-sm aspect-square contain-content "
-              />
-              <Box className="flex flex-col pl-4 gap-1">
-                <h4 className="text-2xl md:text-3xl lg:text-4xl font-medium">
-                  {workshop.attributes.WorkshopTitle}
-                </h4>
-                <Typography>{eventDetails}</Typography>
-                <div className="flex md:gap-7 gap-1 md:flex-row flex-col mt-1">
-                  {workshop.attributes.workshopSlides && (
-                    <Link
-                      underline={"hover"}
-                      className="self-start"
-                      onClick={(event) => handleViewSlides(event, workshop)}
-                      sx={{
-                        "&:hover": {
-                          color: "#57bf94",
-                        },
-                      }}
-                    >
-                      <p className="flex gap-2 mt-1 items-center font-bold text-factory-green text-sm">
-                        <Presentation size={20} />
-                        View Workshop Slides
-                      </p>
-                    </Link>
-                  )}
+              <Box className="flex flex-row items-start gap-3 w-full min-w-0">
+                <Box
+                  component="img"
+                  src={`https://factorystrapi.mcgilleus.ca${workshop.attributes.CoverPicture.data[0].attributes.url}`}
+                  className="h-16 w-16 sm:h-20 sm:w-20 md:h-24 md:w-24 rounded-sm aspect-square shrink-0 object-cover"
+                />
+                <Box className="flex flex-col gap-1 min-w-0 flex-1">
+                  <h4 className="text-lg sm:text-2xl md:text-3xl lg:text-4xl font-medium leading-tight">
+                    {workshop.attributes.WorkshopTitle}
+                  </h4>
+                  <Typography className="text-sm sm:text-base break-words">{eventDetails}</Typography>
+                  <div className="flex gap-3 sm:gap-7 flex-row flex-wrap mt-1">
+                    {workshop.attributes.workshopSlides && (
+                      <Link
+                        underline={"hover"}
+                        className="self-start"
+                        onClick={(event) => handleViewSlides(event, workshop)}
+                        sx={{
+                          "&:hover": {
+                            color: "#57bf94",
+                          },
+                        }}
+                      >
+                        <p className="flex gap-2 mt-1 items-center font-bold text-factory-green text-sm">
+                          <Presentation size={18} />
+                          View Workshop Slides
+                        </p>
+                      </Link>
+                    )}
 
-                  {workshop.attributes.signupLink && isFutureWorkshop && (
-                    <Link
-                      underline={"hover"}
-                      className="self-start"
-                      onClick={(event) => handleSignUp(event, workshop)}
-                      sx={{
-                        "&:hover": {
-                          color: "#57bf94",
-                        },
-                      }}
-                    >
-                      <p className="flex gap-2 mt-1 items-center font-bold text-factory-green text-sm">
-                        <UserRoundCheck size={20} />
-                        Sign Up Form
-                      </p>
-                    </Link>
-                  )}
-                </div>
+                    {workshop.attributes.signupLink && isFutureWorkshop && (
+                      <Link
+                        underline={"hover"}
+                        className="self-start"
+                        onClick={(event) => handleSignUp(event, workshop)}
+                        sx={{
+                          "&:hover": {
+                            color: "#57bf94",
+                          },
+                        }}
+                      >
+                        <p className="flex gap-2 mt-1 items-center font-bold text-factory-green text-sm">
+                          <UserRoundCheck size={18} />
+                          Sign Up Form
+                        </p>
+                      </Link>
+                    )}
+                  </div>
+                </Box>
               </Box>
             </AccordionSummary>
             <AccordionDetails className="pt-4">


### PR DESCRIPTION
## Changes

- **`workshops/page.tsx`**: Expanded container from `max-w-4xl` to `max-w-6xl` and improved horizontal padding with responsive values (`px-4 sm:px-6 lg:px-10`).
- **`PageSection.tsx`**: Removed the `md:w-8/12` constraint that was capping the section to 66% width — now uses `w-full max-w-7xl` so content spans the available space. Also fixed the `className` concatenation to avoid a missing leading space.
- **`WorkshopAccordion.tsx`**: Made accordion items fully fluid with `w-full`/`min-w-0`/`flex-1` so text doesn't overflow. Thumbnail sizes are now responsive (`h-16 w-16 → h-24 w-24`), title scales down on small screens, and the slides/sign-up links wrap instead of stacking vertically.