### PR TITLE
Revamp /our-lab — modern gallery style

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -71,6 +71,14 @@ its going to be under something like const styles = {}
     background-size: 24px 24px;
     opacity: 0.1;
   }
+
+  .section-divider {
+    width: 48px;
+    height: 2px;
+    background: #57bf94;
+    margin: 12px auto 0;
+    border-radius: 999px;
+  }
 }
 
 body {

--- a/frontend/src/app/our-lab/page.tsx
+++ b/frontend/src/app/our-lab/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useManagerAndLabData } from "@/Contexts/ManagerAndLabContext";
-import LabSectionComponent from "@/components/LabSectionComponent";
+import LabGallerySection from "@/components/LabGallerySection";
 import Spinner from "@/components/Spinner";
 
 export default function OurLab() {
@@ -10,43 +10,79 @@ export default function OurLab() {
   if (!labSections) return <Spinner />;
 
   return (
-    <div className="bg-factory-black min-h-screen">
-      {/* Header */}
-      <div className="relative overflow-hidden bg-factory-black pt-16 pb-12 px-6">
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_70%_60%_at_50%_50%,rgba(87,191,148,0.08),transparent)]" />
-        <div className="relative max-w-5xl mx-auto text-center">
-          <h1 className="text-4xl md:text-5xl font-bold text-white mb-3">Our Lab</h1>
-          <div className="section-divider" />
-          <p className="text-white/50 text-base max-w-xl mx-auto mt-2">
-            Explore our state-of-the-art hardware and equipment available to members.
+    <main className="bg-factory-dark-black min-h-screen">
+      {/* Hero */}
+      <section className="relative flex flex-col items-center justify-center px-6 pt-24 pb-20 overflow-hidden">
+        {/* Subtle grid backdrop */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(87,191,148,0.04) 1px,transparent 1px),linear-gradient(90deg,rgba(87,191,148,0.04) 1px,transparent 1px)",
+            backgroundSize: "48px 48px",
+          }}
+        />
+
+        {/* Glow */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] rounded-full blur-3xl opacity-20"
+          style={{ background: "radial-gradient(ellipse,#57bf94 0%,transparent 70%)" }}
+        />
+
+        <div className="relative z-10 text-center max-w-3xl mx-auto">
+          <span className="inline-block text-factory-green text-xs font-semibold uppercase tracking-[0.22em] mb-4 border border-factory-green/30 rounded-full px-4 py-1.5">
+            Equipment &amp; Workspace
+          </span>
+          <h1 className="text-5xl md:text-7xl font-bold text-white leading-[1.05] tracking-tight text-balance">
+            Our Lab
+          </h1>
+          <p className="mt-5 text-white/50 text-lg leading-relaxed max-w-lg mx-auto text-pretty">
+            State-of-the-art hardware and equipment available to every Factory member.
           </p>
         </div>
-      </div>
+      </section>
 
-      {/* Hero Images */}
-      <div className="px-6 pb-12">
-        <div className="max-w-5xl mx-auto flex flex-col lg:flex-row gap-4 justify-center">
-          <img
-            src="/FactoryFriendlyRobot.JPG"
-            alt="Factory Robot"
-            className="h-[420px] object-cover object-bottom rounded-2xl w-full lg:w-[48%] shadow-2xl"
-          />
-          <img
-            src="/robotArm.JPG"
-            alt="Robot Arm"
-            className="h-[420px] object-cover object-bottom rounded-2xl w-full lg:w-[48%] shadow-2xl"
-          />
+      {/* Hero photo strip */}
+      <section className="px-6 pb-16">
+        <div className="max-w-6xl mx-auto grid grid-cols-2 lg:grid-cols-4 gap-3">
+          {[
+            { src: "/lab/IMG_0708.jpg", alt: "Lab overview", span: "col-span-2 row-span-2" },
+            { src: "/lab/IMG_0709.jpg", alt: "Equipment detail" },
+            { src: "/lab/IMG_0713.jpg", alt: "Workstation" },
+            { src: "/lab/IMG_0714.jpg", alt: "Lab tools", span: "col-span-2" },
+          ].map(({ src, alt, span = "" }) => (
+            <div
+              key={src}
+              className={`${span} overflow-hidden rounded-2xl bg-white/5`}
+            >
+              <img
+                src={src}
+                alt={alt}
+                className="w-full h-full min-h-[180px] object-cover transition-transform duration-700 hover:scale-105"
+              />
+            </div>
+          ))}
         </div>
+      </section>
+
+      {/* Divider */}
+      <div className="max-w-6xl mx-auto px-6">
+        <div className="h-px bg-white/10" />
       </div>
 
-      {/* Lab Sections */}
-      {labSections.map((labSection) => (
-        <LabSectionComponent
-          key={labSection.id}
-          SectionTitle={labSection.attributes.SectionTitle}
-          LabSectionRows={labSection.attributes.LabSectionRows}
-        />
-      ))}
-    </div>
+      {/* Equipment gallery sections */}
+      <div className="py-8">
+        {labSections.map((labSection, idx) => (
+          <LabGallerySection
+            key={labSection.id}
+            index={idx}
+            SectionTitle={labSection.attributes.SectionTitle}
+            LabSectionRows={labSection.attributes.LabSectionRows}
+          />
+        ))}
+      </div>
+    </main>
   );
 }

--- a/frontend/src/components/LabGallerySection.tsx
+++ b/frontend/src/components/LabGallerySection.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { LabSectionRow } from "../types/LabSectionRow";
+
+type Props = {
+  SectionTitle: string;
+  LabSectionRows: LabSectionRow[];
+  index: number;
+};
+
+const STRAPI_BASE = "https://factorystrapi.mcgilleus.ca";
+
+export default function LabGallerySection({ SectionTitle, LabSectionRows, index }: Props) {
+  const [lightboxIdx, setLightboxIdx] = useState<number | null>(null);
+
+  const openLightbox = (i: number) => setLightboxIdx(i);
+  const closeLightbox = () => setLightboxIdx(null);
+  const prev = () => setLightboxIdx((i) => (i !== null ? (i - 1 + LabSectionRows.length) % LabSectionRows.length : 0));
+  const next = () => setLightboxIdx((i) => (i !== null ? (i + 1) % LabSectionRows.length : 0));
+
+  return (
+    <section className="py-16 px-6">
+      <div className="max-w-6xl mx-auto">
+        {/* Section header */}
+        <div className="flex items-end justify-between mb-10 gap-4">
+          <div className="flex items-center gap-4">
+            <span className="text-factory-green font-mono text-sm opacity-60 tabular-nums select-none">
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-white tracking-tight">
+              {SectionTitle}
+            </h2>
+          </div>
+          <div className="hidden sm:block h-px flex-1 bg-white/10 ml-4" />
+          <span className="text-white/30 text-sm whitespace-nowrap">
+            {LabSectionRows.length} item{LabSectionRows.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+
+        {/* Masonry-style grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {LabSectionRows.map((row, i) => {
+            const description = row.Description ? row.Description[0] : null;
+            const bullets = description?.children?.flatMap((c) =>
+              c.children?.map((ch) => ch.text).filter(Boolean) ?? []
+            ) ?? [];
+            const imgUrl = `${STRAPI_BASE}${row.Image.data.attributes.url}`;
+
+            // Give first card a wider span for visual rhythm
+            const isFeature = i === 0 && LabSectionRows.length >= 3;
+
+            return (
+              <div
+                key={i}
+                className={`group relative rounded-2xl overflow-hidden bg-white/5 border border-white/8 hover:border-factory-green/40 transition-all duration-300 cursor-pointer ${
+                  isFeature ? "sm:col-span-2" : ""
+                }`}
+                onClick={() => openLightbox(i)}
+                role="button"
+                tabIndex={0}
+                aria-label={`View ${SectionTitle} item ${i + 1}`}
+                onKeyDown={(e) => e.key === "Enter" && openLightbox(i)}
+              >
+                {/* Image */}
+                <div className={`overflow-hidden ${isFeature ? "h-72 sm:h-80" : "h-64"}`}>
+                  <img
+                    src={imgUrl}
+                    alt={`${SectionTitle} — item ${i + 1}`}
+                    loading="lazy"
+                    className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+                  />
+                </div>
+
+                {/* Overlay gradient */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+
+                {/* Hover: expand icon hint */}
+                <div className="absolute top-3 right-3 w-8 h-8 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-300 border border-white/20">
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                    <path d="M2 12L12 2M12 2H7M12 2V7" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </div>
+
+                {/* Bullets */}
+                {bullets.length > 0 && (
+                  <div className="p-4 border-t border-white/8">
+                    <ul className="space-y-1">
+                      {bullets.map((b, bi) => (
+                        <li key={bi} className="flex items-start gap-2 text-sm text-white/70">
+                          <span className="mt-1.5 w-1 h-1 rounded-full bg-factory-green flex-shrink-0" aria-hidden="true" />
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Lightbox */}
+      {lightboxIdx !== null && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-md p-4"
+          onClick={closeLightbox}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${SectionTitle} lightbox`}
+        >
+          {/* Card — stop propagation so clicking card doesn't close */}
+          <div
+            className="relative max-w-4xl w-full rounded-2xl overflow-hidden shadow-2xl bg-factory-dark-black border border-white/10"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={closeLightbox}
+              className="absolute top-3 right-3 z-10 w-9 h-9 rounded-full bg-black/60 flex items-center justify-center text-white hover:bg-factory-green/80 transition-colors"
+              aria-label="Close lightbox"
+            >
+              <X size={16} />
+            </button>
+
+            <img
+              src={`${STRAPI_BASE}${LabSectionRows[lightboxIdx].Image.data.attributes.url}`}
+              alt={`${SectionTitle} — item ${lightboxIdx + 1}`}
+              className="w-full max-h-[70vh] object-contain"
+            />
+
+            {/* Description */}
+            {(() => {
+              const desc = LabSectionRows[lightboxIdx].Description?.[0];
+              const bullets = desc?.children?.flatMap((c) =>
+                c.children?.map((ch) => ch.text).filter(Boolean) ?? []
+              ) ?? [];
+              return bullets.length > 0 ? (
+                <div className="p-5 border-t border-white/10">
+                  <ul className="grid sm:grid-cols-2 gap-x-8 gap-y-2">
+                    {bullets.map((b, bi) => (
+                      <li key={bi} className="flex items-start gap-2 text-sm text-white/75">
+                        <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-factory-green flex-shrink-0" aria-hidden="true" />
+                        {b}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null;
+            })()}
+
+            {/* Counter + nav */}
+            <div className="flex items-center justify-between px-5 py-3 border-t border-white/10 bg-white/5">
+              <span className="text-white/40 text-xs font-mono tabular-nums">
+                {lightboxIdx + 1} / {LabSectionRows.length}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={prev}
+                  className="w-9 h-9 rounded-full border border-white/20 flex items-center justify-center text-white hover:border-factory-green hover:text-factory-green transition-colors"
+                  aria-label="Previous item"
+                >
+                  <ChevronLeft size={16} />
+                </button>
+                <button
+                  onClick={next}
+                  className="w-9 h-9 rounded-full border border-white/20 flex items-center justify-center text-white hover:border-factory-green hover:text-factory-green transition-colors"
+                  aria-label="Next item"
+                >
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Section divider */}
+      <div className="max-w-6xl mx-auto mt-16">
+        <div className="h-px bg-white/8" />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Our Lab — Gallery Revamp

Completely redesigns the `/our-lab` page with a modern gallery aesthetic.

### Changes

**`src/app/our-lab/page.tsx`**
- Full hero section with subtle grid backdrop, radial glow, and a pill tag
- Photo strip using a CSS grid layout showcasing the 4 lab images with hover zoom

**`src/components/LabGallerySection.tsx`** (new)
- Replaces `LabSectionComponent` for the Our Lab page
- Masonry-style 3-column grid; first card spans 2 columns for visual rhythm
- Hover reveals overlay gradient + expand icon
- Full lightbox modal with keyboard navigation (prev/next/close), bullet-point spec list, and counter
- Fully accessible: `role="dialog"`, `aria-modal`, `aria-label`, keyboard support

**`src/app/globals.css`**
- Adds `.section-divider` utility class