### PR TITLE
Office hours: horizontal scroll on small screens

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "factorystrapi.mcgilleus.ca",
+        pathname: "/uploads/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/components/ManagerCard.tsx
+++ b/frontend/src/components/ManagerCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Avatar } from "@mui/material";
+import Image from "next/image";
 import { FactoryManager } from "../types/FactoryManager";
+
+const STRAPI_BASE = "https://factorystrapi.mcgilleus.ca";
 
 export default function ManagerCard(props: {
   manager: FactoryManager;
@@ -9,21 +11,31 @@ export default function ManagerCard(props: {
 }) {
   const { manager } = props;
   const pictureUrl = manager.attributes.picture.data
-    ? `https://factorystrapi.mcgilleus.ca${manager.attributes.picture.data.attributes.url}`
-    : undefined;
+    ? `${STRAPI_BASE}${manager.attributes.picture.data.attributes.url}`
+    : null;
 
   return (
     <button
       onClick={() => props.onClick(manager)}
       className="group flex flex-col items-center gap-2 p-4 rounded-2xl hover:bg-white/8 transition-all duration-200 w-full text-center"
     >
-      <div className="relative">
-        <Avatar
-          alt={manager.attributes.First_Name}
-          src={pictureUrl ?? "/static/images/avatar/1.jpg"}
-          sx={{ width: "5rem", height: "5rem" }}
-          className="ring-2 ring-transparent group-hover:ring-factory-green transition-all duration-200"
-        />
+      {/* Avatar with fixed aspect ratio container to prevent layout shift */}
+      <div className="relative w-20 h-20 rounded-full overflow-hidden ring-2 ring-transparent group-hover:ring-factory-green transition-all duration-200 shrink-0 bg-white/10">
+        {pictureUrl ? (
+          <Image
+            src={pictureUrl}
+            alt={manager.attributes.First_Name}
+            fill
+            sizes="80px"
+            className="object-cover object-top"
+            loading="lazy"
+            quality={60}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-factory-green/20 text-factory-green font-bold text-lg select-none">
+            {manager.attributes.First_Name?.charAt(0) ?? "?"}
+          </div>
+        )}
       </div>
 
       <div className="flex flex-col items-center gap-0.5">

--- a/frontend/src/components/ManagerCard.tsx
+++ b/frontend/src/components/ManagerCard.tsx
@@ -17,36 +17,39 @@ export default function ManagerCard(props: {
   return (
     <button
       onClick={() => props.onClick(manager)}
-      className="group flex flex-col items-center gap-2 p-4 rounded-2xl hover:bg-white/8 transition-all duration-200 w-full text-center"
+      aria-label={`View profile of ${manager.attributes.First_Name} ${manager.attributes.Last_Name}`}
+      className="group flex flex-col items-center gap-3 p-5 rounded-xl w-full text-center
+                 hover:bg-white/5 active:bg-white/8 transition-colors duration-150"
     >
-      {/* Avatar with fixed aspect ratio container to prevent layout shift */}
-      <div className="relative w-20 h-20 rounded-full overflow-hidden ring-2 ring-transparent group-hover:ring-factory-green transition-all duration-200 shrink-0 bg-white/10">
+      {/* Avatar */}
+      <div className="relative w-[72px] h-[72px] rounded-full overflow-hidden shrink-0
+                      ring-2 ring-white/10 group-hover:ring-factory-green/60
+                      transition-all duration-200 bg-white/5">
         {pictureUrl ? (
           <Image
             src={pictureUrl}
             alt={manager.attributes.First_Name}
             fill
-            sizes="80px"
+            sizes="72px"
             className="object-cover object-top"
             loading="lazy"
             quality={60}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center bg-factory-green/20 text-factory-green font-bold text-lg select-none">
+          <span className="absolute inset-0 flex items-center justify-center
+                           text-factory-green font-bold text-xl select-none">
             {manager.attributes.First_Name?.charAt(0) ?? "?"}
-          </div>
+          </span>
         )}
       </div>
 
-      <div className="flex flex-col items-center gap-0.5">
-        <span className="text-white font-semibold text-sm leading-tight">
-          {manager.attributes.Modified_First_Name}
+      {/* Text */}
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-white font-semibold text-sm leading-tight text-balance">
+          {manager.attributes.Modified_First_Name ?? manager.attributes.First_Name}
         </span>
-        <span className="text-white/50 text-xs">
+        <span className="text-white/40 text-xs leading-snug text-balance">
           {manager.attributes.Role}
-        </span>
-        <span className="text-factory-green text-xs font-medium mt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          View Profile →
         </span>
       </div>
     </button>

--- a/frontend/src/components/ManagerInfo.tsx
+++ b/frontend/src/components/ManagerInfo.tsx
@@ -1,17 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import {
-  Chip,
-  Dialog,
-  DialogContent,
-  Divider,
-  Link,
-} from "@mui/material";
-import Typography from "@mui/material/Typography";
-import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import { Close } from "@mui/icons-material";
+import { useEffect } from "react";
 import { FactoryManager } from "../types/FactoryManager";
 
 const STRAPI_BASE = "https://factorystrapi.mcgilleus.ca";
@@ -31,7 +21,17 @@ export default function ManagerInfo(props: {
 }) {
   const { manager, open, onClose } = props;
 
-  if (!manager) return null;
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open || !manager) return null;
 
   const pictureUrl = manager.attributes.picture.data
     ? `${STRAPI_BASE}${manager.attributes.picture.data.attributes.url}`
@@ -40,86 +40,126 @@ export default function ManagerInfo(props: {
   const initials = `${manager.attributes.First_Name?.charAt(0) ?? ""}${manager.attributes.Last_Name?.charAt(0) ?? ""}`;
 
   return (
-    <Dialog open={open} maxWidth="sm" fullWidth onClose={onClose}>
-      <DialogContent className="flex flex-col items-start">
-        <Box className="flex flex-row w-full justify-between">
-          <Box className="flex flex-row items-center pb-4 gap-4">
-            {/* Avatar — fixed 96×96 container to prevent layout shift */}
-            <div className="relative w-24 h-24 rounded-full overflow-hidden shrink-0 bg-gray-100">
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backgroundColor: "rgba(0,0,0,0.7)", backdropFilter: "blur(4px)" }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${manager.attributes.First_Name} ${manager.attributes.Last_Name} details`}
+    >
+      {/* Panel */}
+      <div
+        className="relative w-full max-w-md rounded-2xl overflow-hidden shadow-2xl"
+        style={{ backgroundColor: "#1e2530", border: "1px solid rgba(87,191,148,0.15)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Top accent bar */}
+        <div className="h-1 w-full bg-factory-green" />
+
+        <div className="p-6">
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="absolute top-5 right-5 w-8 h-8 flex items-center justify-center rounded-full text-white/40 hover:text-white hover:bg-white/10 transition-colors duration-150"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M2 2l12 12M14 2L2 14" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round"/>
+            </svg>
+          </button>
+
+          {/* Header row */}
+          <div className="flex items-center gap-4 mb-5">
+            {/* Avatar */}
+            <div className="relative w-20 h-20 rounded-xl overflow-hidden shrink-0 bg-factory-green/10">
               {pictureUrl ? (
                 <Image
                   src={pictureUrl}
                   alt={manager.attributes.First_Name}
                   fill
-                  sizes="96px"
+                  sizes="80px"
                   className="object-cover object-top"
                   loading="eager"
                   quality={75}
                 />
               ) : (
-                <div className="w-full h-full flex items-center justify-center bg-factory-green/20 text-factory-green font-bold text-xl select-none">
+                <div className="w-full h-full flex items-center justify-center text-factory-green font-bold text-2xl select-none">
                   {initials}
                 </div>
               )}
             </div>
 
-            <Box className="flex flex-col">
-              <Typography variant="h6">
+            {/* Name + meta */}
+            <div className="flex flex-col gap-0.5 min-w-0">
+              <h3 className="text-white font-semibold text-lg leading-tight truncate">
                 {manager.attributes.First_Name} {manager.attributes.Last_Name}
-              </Typography>
-              <Typography variant="caption">
-                {manager.attributes.Role}
-              </Typography>
-              <Typography variant="caption">
-                {manager.attributes.Year_Major}
-              </Typography>
-
-              {manager.attributes.Office_Hour_Day ? (
-                <Typography variant="caption">
-                  Office Hours: {manager.attributes.Office_Hour_Day},{" "}
-                  {formatTime(manager.attributes.Start_Time)} -{" "}
-                  {formatTime(manager.attributes.End_Time)}
-                </Typography>
-              ) : null}
-
-              <Link
-                color="#4ca981"
-                underline="hover"
-                href={`mailto:${manager.attributes.McGill_Email}`}
-              >
-                <Typography variant="caption">
-                  {manager.attributes.McGill_Email}
-                </Typography>
-              </Link>
-            </Box>
-          </Box>
-
-          <IconButton className="self-start" onClick={onClose} aria-label="Close">
-            <Close />
-          </IconButton>
-        </Box>
-
-        {manager.attributes.Skills && manager.attributes.Skills.length > 0 ? (
-          <>
-            <Divider className="w-full" />
-            <div className="w-full">
-              <Typography variant="h6" className="text-left">
-                Skills
-              </Typography>
-              <div className="flex flex-wrap gap-1 h-fit max-h-48 overflow-y-auto py-2">
-                {manager.attributes.Skills.map((skill, index) => (
-                  <Chip
-                    key={index}
-                    className="text-center"
-                    label={skill.skill}
-                    onClick={() => undefined}
-                  />
-                ))}
-              </div>
+              </h3>
+              {manager.attributes.Role && (
+                <span className="text-factory-green text-sm font-medium truncate">
+                  {manager.attributes.Role}
+                </span>
+              )}
+              {manager.attributes.Year_Major && (
+                <span className="text-white/50 text-xs truncate">
+                  {manager.attributes.Year_Major}
+                </span>
+              )}
             </div>
-          </>
-        ) : null}
-      </DialogContent>
-    </Dialog>
+          </div>
+
+          {/* Info rows */}
+          <div className="flex flex-col gap-2 mb-5">
+            {manager.attributes.Office_Hour_Day && (
+              <div className="flex items-start gap-2">
+                <svg className="w-4 h-4 text-factory-green mt-0.5 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
+                </svg>
+                <span className="text-white/70 text-sm leading-relaxed">
+                  {manager.attributes.Office_Hour_Day},{" "}
+                  {formatTime(manager.attributes.Start_Time)} &ndash;{" "}
+                  {formatTime(manager.attributes.End_Time)}
+                </span>
+              </div>
+            )}
+            {manager.attributes.McGill_Email && (
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-factory-green shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                  <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                </svg>
+                <a
+                  href={`mailto:${manager.attributes.McGill_Email}`}
+                  className="text-factory-green hover:text-factory-dark-green text-sm underline underline-offset-2 transition-colors duration-150 truncate"
+                >
+                  {manager.attributes.McGill_Email}
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* Skills */}
+          {manager.attributes.Skills && manager.attributes.Skills.length > 0 && (
+            <>
+              <div className="h-px w-full mb-4" style={{ backgroundColor: "rgba(87,191,148,0.15)" }} />
+              <div>
+                <h4 className="text-white/50 text-xs font-semibold uppercase tracking-widest mb-3">Skills</h4>
+                <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto">
+                  {manager.attributes.Skills.map((skill, index) => (
+                    <span
+                      key={index}
+                      className="inline-block px-2.5 py-1 rounded-full text-xs font-medium bg-factory-green/15 text-factory-green border border-factory-green/20"
+                    >
+                      {skill.skill}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/ManagerInfo.tsx
+++ b/frontend/src/components/ManagerInfo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import Image from "next/image";
 import {
-  Avatar,
   Chip,
   Dialog,
   DialogContent,
@@ -13,6 +13,8 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import { Close } from "@mui/icons-material";
 import { FactoryManager } from "../types/FactoryManager";
+
+const STRAPI_BASE = "https://factorystrapi.mcgilleus.ca";
 
 function formatTime(date: Date): string {
   return date.toLocaleTimeString([], {
@@ -27,36 +29,41 @@ export default function ManagerInfo(props: {
   open: boolean;
   onClose: () => void;
 }) {
-  // Destructure props for cleaner access
   const { manager, open, onClose } = props;
 
-  // Return early if manager is null to avoid rendering unnecessary content
-  if (!manager) {
-    return null;
-  }
+  if (!manager) return null;
 
+  const pictureUrl = manager.attributes.picture.data
+    ? `${STRAPI_BASE}${manager.attributes.picture.data.attributes.url}`
+    : null;
 
+  const initials = `${manager.attributes.First_Name?.charAt(0) ?? ""}${manager.attributes.Last_Name?.charAt(0) ?? ""}`;
 
   return (
     <Dialog open={open} maxWidth="sm" fullWidth onClose={onClose}>
       <DialogContent className="flex flex-col items-start">
         <Box className="flex flex-row w-full justify-between">
-          <Box className="flex flex-row items-center pb-4">
-            {manager.attributes.picture.data ? (
-              <Avatar
-                alt={manager.attributes.First_Name}
-                src={`https://factorystrapi.mcgilleus.ca${manager.attributes.picture.data.attributes.url}`}
-                sx={{ width: "6rem", height: "6rem" }}
-              />
-            ) : (
-              <Avatar
-                alt={manager.attributes.First_Name}
-                src="/static/images/avatar/1.jpg"
-                sx={{ width: "6rem", height: "6rem" }}
-              />
-            )}
+          <Box className="flex flex-row items-center pb-4 gap-4">
+            {/* Avatar — fixed 96×96 container to prevent layout shift */}
+            <div className="relative w-24 h-24 rounded-full overflow-hidden shrink-0 bg-gray-100">
+              {pictureUrl ? (
+                <Image
+                  src={pictureUrl}
+                  alt={manager.attributes.First_Name}
+                  fill
+                  sizes="96px"
+                  className="object-cover object-top"
+                  loading="eager"
+                  quality={75}
+                />
+              ) : (
+                <div className="w-full h-full flex items-center justify-center bg-factory-green/20 text-factory-green font-bold text-xl select-none">
+                  {initials}
+                </div>
+              )}
+            </div>
 
-            <Box className="flex flex-col ml-4">
+            <Box className="flex flex-col">
               <Typography variant="h6">
                 {manager.attributes.First_Name} {manager.attributes.Last_Name}
               </Typography>
@@ -86,21 +93,21 @@ export default function ManagerInfo(props: {
               </Link>
             </Box>
           </Box>
-          <IconButton className="self-start" onClick={onClose}>
+
+          <IconButton className="self-start" onClick={onClose} aria-label="Close">
             <Close />
           </IconButton>
         </Box>
 
-        {props.manager?.attributes.Skills &&
-        props.manager?.attributes.Skills.length > 0 ? (
+        {manager.attributes.Skills && manager.attributes.Skills.length > 0 ? (
           <>
             <Divider className="w-full" />
             <div className="w-full">
               <Typography variant="h6" className="text-left">
                 Skills
               </Typography>
-              <div className="flex flex-wrap gap-1 h-fit max-h-48 overflow-scroll py-2">
-                {props.manager?.attributes.Skills?.map((skill, index) => (
+              <div className="flex flex-wrap gap-1 h-fit max-h-48 overflow-y-auto py-2">
+                {manager.attributes.Skills.map((skill, index) => (
                   <Chip
                     key={index}
                     className="text-center"

--- a/frontend/src/components/ManagerSection.tsx
+++ b/frontend/src/components/ManagerSection.tsx
@@ -36,24 +36,24 @@ export function ManagerSection(props: ManagerSectionProps) {
   };
 
   return (
-    <section className="bg-factory-black text-white py-16 px-6">
+    <section className="bg-[#1a1e24] text-white py-16 px-6">
       <div className="max-w-6xl mx-auto">
+
         {/* Header */}
-        <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold">Managers</h2>
-          <div className="section-divider" />
+        <div className="mb-14">
+          <span className="text-factory-green text-xs font-bold uppercase tracking-widest">
+            The Team
+          </span>
+          <h2 className="text-4xl font-bold mt-2 text-balance">Managers</h2>
+          <div className="h-px bg-white/10 mt-6" />
         </div>
 
         {/* Steering Committee */}
         <div className="mb-14">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="h-px flex-1 bg-white/10" />
-            <span className="text-white/50 text-sm font-semibold uppercase tracking-widest px-3">
-              Steering Committee
-            </span>
-            <div className="h-px flex-1 bg-white/10" />
-          </div>
-          <Grid container className="justify-center">
+          <p className="text-white/40 text-xs font-semibold uppercase tracking-widest mb-8">
+            Steering Committee
+          </p>
+          <Grid container spacing={0}>
             {steeringCommittee.map((manager) => (
               <Grid size={{ xs: 6, sm: 4, md: 3, lg: 2 }} key={manager.id}>
                 <ManagerCard manager={manager} onClick={selectManager} />
@@ -62,16 +62,14 @@ export function ManagerSection(props: ManagerSectionProps) {
           </Grid>
         </div>
 
+        <div className="h-px bg-white/10 mb-14" />
+
         {/* General Managers */}
         <div>
-          <div className="flex items-center gap-3 mb-6">
-            <div className="h-px flex-1 bg-white/10" />
-            <span className="text-white/50 text-sm font-semibold uppercase tracking-widest px-3">
-              General Managers
-            </span>
-            <div className="h-px flex-1 bg-white/10" />
-          </div>
-          <Grid container className="justify-center">
+          <p className="text-white/40 text-xs font-semibold uppercase tracking-widest mb-8">
+            General Managers
+          </p>
+          <Grid container spacing={0}>
             {generalManagers.map((manager) => (
               <Grid size={{ xs: 6, sm: 4, md: 3, lg: 2 }} key={manager.id}>
                 <ManagerCard manager={manager} onClick={selectManager} />
@@ -79,6 +77,7 @@ export function ManagerSection(props: ManagerSectionProps) {
             ))}
           </Grid>
         </div>
+
       </div>
 
       <ManagerInfo manager={selectedManager} open={open} onClose={() => setOpen(false)} />

--- a/frontend/src/components/WeekView.tsx
+++ b/frontend/src/components/WeekView.tsx
@@ -57,7 +57,7 @@ export default function WeekView(props: {
               <span className="hidden md:inline">{day}</span>
               <span className="md:hidden">{dayAbbr[i]}</span>
             </div>
-            <div className="rounded-lg bg-gray-100 text-gray-400 text-xs text-center py-3 px-1">
+            <div className="rounded-lg bg-white/5 text-white/30 text-xs text-center py-3 px-1">
               Not yet finalized
             </div>
           </div>
@@ -72,7 +72,7 @@ export default function WeekView(props: {
         {days.map((day, dayIndex) => (
           <div key={dayIndex} className="flex flex-col">
             {/* Day header */}
-            <div className="text-center text-[0.65rem] md:text-xs font-bold uppercase tracking-widest text-gray-400 mb-3">
+            <div className="text-center text-[0.65rem] md:text-xs font-bold uppercase tracking-widest text-white/40 mb-3">
               <span className="hidden md:inline">{day}</span>
               <span className="md:hidden">{dayAbbr[dayIndex]}</span>
             </div>
@@ -81,7 +81,7 @@ export default function WeekView(props: {
             <div className="flex flex-col" style={{ gap: `${SLOT_GAP_PX}px` }}>
               {(props.officeHours[day] ?? []).length === 0 ? (
                 <div
-                  className="rounded-xl border border-dashed border-gray-200 text-gray-300 text-[0.6rem] text-center flex items-center justify-center"
+                  className="rounded-xl border border-dashed border-white/10 text-white/20 text-xs text-center flex items-center justify-center"
                   style={{ height: `${SLOT_HEIGHT_PX * 2}px` }}
                 >
                   —
@@ -97,19 +97,19 @@ export default function WeekView(props: {
                     <button
                       key={index}
                       onClick={() => selectManager(officeHour)}
-                      className="group relative w-full rounded-xl bg-factory-green/10 border border-factory-green/30 hover:bg-factory-green hover:border-factory-green text-left overflow-hidden transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-factory-green focus:ring-offset-1"
+                      className="group relative w-full rounded-xl bg-factory-green/15 border border-factory-green/25 hover:bg-factory-green hover:border-factory-green text-left overflow-hidden transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-factory-green focus:ring-offset-2 focus:ring-offset-factory-dark-black"
                       style={{ height: `${blockHeight}px` }}
                       aria-label={`${officeHour.attributes.First_Name} office hours: ${toTimeString(officeHour.attributes.Start_Time)} to ${toTimeString(officeHour.attributes.End_Time)}`}
                     >
                       {/* Accent stripe */}
-                      <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-factory-green group-hover:bg-white/60 transition-colors duration-200 rounded-l-xl" />
+                      <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-factory-green group-hover:bg-white/50 transition-colors duration-200 rounded-l-xl" />
 
-                      <div className="pl-2 pr-1 py-1 flex flex-col justify-center h-full">
-                        <span className="block text-[0.6rem] md:text-xs font-semibold text-factory-dark-green group-hover:text-white leading-tight truncate transition-colors duration-200">
+                      <div className="pl-3 pr-1.5 py-1.5 flex flex-col justify-center h-full">
+                        <span className="block text-xs md:text-sm font-semibold text-factory-green group-hover:text-white leading-tight truncate transition-colors duration-200">
                           {officeHour.attributes.First_Name}
                         </span>
                         {blockHeight >= SLOT_HEIGHT_PX * 1.5 && (
-                          <span className="block text-[0.55rem] md:text-[0.65rem] text-gray-500 group-hover:text-white/80 leading-tight transition-colors duration-200 mt-0.5">
+                          <span className="block text-[0.65rem] md:text-xs text-factory-green/70 group-hover:text-white/80 leading-tight transition-colors duration-200 mt-1">
                             {toTimeString(officeHour.attributes.Start_Time)}
                             <br />
                             {toTimeString(officeHour.attributes.End_Time)}

--- a/frontend/src/components/WeekView.tsx
+++ b/frontend/src/components/WeekView.tsx
@@ -30,7 +30,7 @@ export default function WeekView(props: {
    * Unit = 30 minutes = SLOT_HEIGHT_PX.
    * So 1 hour = 2 × SLOT_HEIGHT_PX, 1.5 hours = 3 × SLOT_HEIGHT_PX (exactly 1.5× the 1-hour block).
    */
-  const SLOT_HEIGHT_PX = 40; // px per 30-minute unit
+  const SLOT_HEIGHT_PX = 52; // px per 30-minute unit
   const SLOT_GAP_PX = 6;     // gap between blocks
 
   function getSlotHeight(start: Date, end: Date): number {
@@ -105,11 +105,11 @@ export default function WeekView(props: {
                       <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-factory-green group-hover:bg-white/50 transition-colors duration-200 rounded-l-xl" />
 
                       <div className="pl-3 pr-1.5 py-1.5 flex flex-col justify-center h-full">
-                        <span className="block text-xs md:text-sm font-semibold text-factory-green group-hover:text-white leading-tight truncate transition-colors duration-200">
+                        <span className="block text-sm md:text-base font-semibold text-factory-green group-hover:text-white leading-tight truncate transition-colors duration-200">
                           {officeHour.attributes.First_Name}
                         </span>
                         {blockHeight >= SLOT_HEIGHT_PX * 1.5 && (
-                          <span className="block text-[0.65rem] md:text-xs text-factory-green/70 group-hover:text-white/80 leading-tight transition-colors duration-200 mt-1">
+                          <span className="block text-xs md:text-sm text-factory-green/70 group-hover:text-white/80 leading-tight transition-colors duration-200 mt-1">
                             {toTimeString(officeHour.attributes.Start_Time)}
                             <br />
                             {toTimeString(officeHour.attributes.End_Time)}

--- a/frontend/src/components/WeekView.tsx
+++ b/frontend/src/components/WeekView.tsx
@@ -10,17 +10,11 @@ export default function WeekView(props: {
   endTime: Date;
 }) {
   const [open, setOpen] = useState(false);
-  const [selectedManager, setSelectedManager] = useState<FactoryManager | null>(
-    null
-  );
+  const [selectedManager, setSelectedManager] = useState<FactoryManager | null>(null);
 
   function selectManager(manager: FactoryManager) {
     setSelectedManager(manager);
     setOpen(true);
-  }
-
-  function calcTimeSlots(start: Date, end: Date): number {
-    return Math.ceil((end.getTime() - start.getTime()) / 1800000); // 30-minute slots
   }
 
   function toTimeString(date: Date): string {
@@ -31,94 +25,107 @@ export default function WeekView(props: {
     });
   }
 
-  function getSlotHeight(startTime: Date, endTime: Date): number {
-    const totalSlots = calcTimeSlots(startTime, endTime);
-    const oneHourHeight = 100; // Base height for 1 hour
-    const additionalSlotHeight = 35; // Smaller height for additional time (30 min)
+  /**
+   * Height is proportional to duration.
+   * Unit = 30 minutes = SLOT_HEIGHT_PX.
+   * So 1 hour = 2 × SLOT_HEIGHT_PX, 1.5 hours = 3 × SLOT_HEIGHT_PX (exactly 1.5× the 1-hour block).
+   */
+  const SLOT_HEIGHT_PX = 40; // px per 30-minute unit
+  const SLOT_GAP_PX = 6;     // gap between blocks
 
-    if (totalSlots <= 2) {
-      // One hour or less
-      return oneHourHeight;
-    } else {
-      // More than one hour
-      return oneHourHeight + (totalSlots - 2) * additionalSlotHeight;
-    }
+  function getSlotHeight(start: Date, end: Date): number {
+    const durationMs = new Date(end).getTime() - new Date(start).getTime();
+    const slots = durationMs / 1800000; // number of 30-min units
+    return Math.max(slots * SLOT_HEIGHT_PX, SLOT_HEIGHT_PX);
   }
 
-  // Check if officeHours contains any valid data
-  const hasValidData = Object.keys(props.officeHours).some((day) =>
-    props.officeHours[day].some(
-      (officeHour) =>
-        officeHour.attributes.Office_Hour_Day &&
-        officeHour.attributes.Start_Time &&
-        officeHour.attributes.End_Time
+  const days = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"];
+  const dayAbbr = ["Mon", "Tue", "Wed", "Thu", "Fri"];
+
+  const hasValidData = days.some((day) =>
+    (props.officeHours[day] ?? []).some(
+      (m) => m.attributes.Office_Hour_Day && m.attributes.Start_Time && m.attributes.End_Time
     )
   );
 
-  // Render a template grid if there is no valid data
   if (!hasValidData) {
     return (
-      <div className="flex justify-center items-center mx-auto py-4">
-        <div className="grid grid-cols-5 lg:gap-5 w-full max-w-6xl">
-          {["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"].map(
-            (day, index) => (
-              <div key={index} className="flex flex-col">
-                <div className="text-center font-semibold h-8 md:text-base text-[0.7rem] lg:mt-4">
-                  {day}
-                </div>
-                <div className="bg-gray-300 text-gray-600 rounded-md lg:p-2 pt-1 px-1 m-1 text-center">
-                  Not yet finalized
-                </div>
-              </div>
-            )
-          )}
-        </div>
+      <div className="grid grid-cols-5 gap-3 w-full">
+        {days.map((day, i) => (
+          <div key={i} className="flex flex-col gap-1">
+            <div className="text-center text-xs font-semibold uppercase tracking-widest text-gray-400 pb-2">
+              <span className="hidden md:inline">{day}</span>
+              <span className="md:hidden">{dayAbbr[i]}</span>
+            </div>
+            <div className="rounded-lg bg-gray-100 text-gray-400 text-xs text-center py-3 px-1">
+              Not yet finalized
+            </div>
+          </div>
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="flex justify-center items-center mx-auto py-4">
-      <div className="grid grid-cols-5 lg:gap-5 w-full max-w-6xl ">
-        {/* Office Hours for each day */}
-        {Object.keys(props.officeHours).map((day, dayIndex) => (
+    <div className="w-full">
+      <div className="grid grid-cols-5 gap-2 md:gap-4 w-full">
+        {days.map((day, dayIndex) => (
           <div key={dayIndex} className="flex flex-col">
-            <div className="text-center font-semibold h-8 md:text-base text-[0.7rem] lg:mt-4">
-              {day}
+            {/* Day header */}
+            <div className="text-center text-[0.65rem] md:text-xs font-bold uppercase tracking-widest text-gray-400 mb-3">
+              <span className="hidden md:inline">{day}</span>
+              <span className="md:hidden">{dayAbbr[dayIndex]}</span>
             </div>
-            {props.officeHours[day].map((officeHour, index) => {
-              return (
+
+            {/* Time blocks */}
+            <div className="flex flex-col" style={{ gap: `${SLOT_GAP_PX}px` }}>
+              {(props.officeHours[day] ?? []).length === 0 ? (
                 <div
-                  key={index}
-                  className="bg-factory-green text-white rounded-md lg:p-2 pt-1 px-1 m-1 cursor-pointer transition-transform transform hover:scale-105 text-center"
-                  style={{
-                    height: `${getSlotHeight(
-                      new Date(officeHour.attributes.Start_Time),
-                      new Date(officeHour.attributes.End_Time)
-                    )}px`, // Adjust height based on duration
-                  }}
-                  onClick={() => selectManager(officeHour)}
+                  className="rounded-xl border border-dashed border-gray-200 text-gray-300 text-[0.6rem] text-center flex items-center justify-center"
+                  style={{ height: `${SLOT_HEIGHT_PX * 2}px` }}
                 >
-                  <div className="text-xs md:text-sm">
-                    {officeHour.attributes.First_Name}
-                  </div>
-                  <div className="text-[0.6rem] md:text-sm">
-                    {toTimeString(officeHour.attributes.Start_Time)} -{" "}
-                    {toTimeString(officeHour.attributes.End_Time)}
-                  </div>
+                  —
                 </div>
-              );
-            })}
+              ) : (
+                (props.officeHours[day] ?? []).map((officeHour, index) => {
+                  const blockHeight = getSlotHeight(
+                    officeHour.attributes.Start_Time,
+                    officeHour.attributes.End_Time
+                  );
+
+                  return (
+                    <button
+                      key={index}
+                      onClick={() => selectManager(officeHour)}
+                      className="group relative w-full rounded-xl bg-factory-green/10 border border-factory-green/30 hover:bg-factory-green hover:border-factory-green text-left overflow-hidden transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-factory-green focus:ring-offset-1"
+                      style={{ height: `${blockHeight}px` }}
+                      aria-label={`${officeHour.attributes.First_Name} office hours: ${toTimeString(officeHour.attributes.Start_Time)} to ${toTimeString(officeHour.attributes.End_Time)}`}
+                    >
+                      {/* Accent stripe */}
+                      <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-factory-green group-hover:bg-white/60 transition-colors duration-200 rounded-l-xl" />
+
+                      <div className="pl-2 pr-1 py-1 flex flex-col justify-center h-full">
+                        <span className="block text-[0.6rem] md:text-xs font-semibold text-factory-dark-green group-hover:text-white leading-tight truncate transition-colors duration-200">
+                          {officeHour.attributes.First_Name}
+                        </span>
+                        {blockHeight >= SLOT_HEIGHT_PX * 1.5 && (
+                          <span className="block text-[0.55rem] md:text-[0.65rem] text-gray-500 group-hover:text-white/80 leading-tight transition-colors duration-200 mt-0.5">
+                            {toTimeString(officeHour.attributes.Start_Time)}
+                            <br />
+                            {toTimeString(officeHour.attributes.End_Time)}
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
           </div>
         ))}
-
-        {/* Manager Info Popup */}
-        <ManagerInfo
-          manager={selectedManager}
-          open={open}
-          onClose={() => setOpen(false)}
-        />
       </div>
+
+      <ManagerInfo manager={selectedManager} open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/components/WeekView.tsx
+++ b/frontend/src/components/WeekView.tsx
@@ -50,7 +50,8 @@ export default function WeekView(props: {
 
   if (!hasValidData) {
     return (
-      <div className="grid grid-cols-5 gap-3 w-full">
+      <div className="w-full overflow-x-auto -mx-2 px-2">
+      <div className="grid grid-cols-5 gap-3" style={{ minWidth: "480px" }}>
         {days.map((day, i) => (
           <div key={i} className="flex flex-col gap-1">
             <div className="text-center text-xs font-semibold uppercase tracking-widest text-gray-400 pb-2">
@@ -63,12 +64,13 @@ export default function WeekView(props: {
           </div>
         ))}
       </div>
+      </div>
     );
   }
 
   return (
-    <div className="w-full">
-      <div className="grid grid-cols-5 gap-2 md:gap-4 w-full">
+    <div className="w-full overflow-x-auto -mx-2 px-2">
+      <div className="grid grid-cols-5 gap-2 md:gap-4" style={{ minWidth: "480px" }}>
         {days.map((day, dayIndex) => (
           <div key={dayIndex} className="flex flex-col">
             {/* Day header */}

--- a/frontend/src/components/WeekViewSection.tsx
+++ b/frontend/src/components/WeekViewSection.tsx
@@ -45,13 +45,34 @@ export function WeekViewSection(props: WeekViewSectionProps) {
   };
 
   return (
-    <section className="py-16 px-6 bg-white min-h-[750px]">
-      <div className="max-w-6xl mx-auto">
+    <section className="py-16 px-6 bg-gray-50 min-h-[600px]">
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
         <div className="text-center mb-10">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900">Office Hours</h2>
-          <div className="section-divider !bg-gradient-to-r from-factory-green to-factory-dark-green" />
-          <p className="text-gray-400 text-sm mt-2">Drop by the lab when a manager is in</p>
+          <span className="inline-block text-factory-green text-xs font-bold uppercase tracking-widest mb-3">
+            Lab Schedule
+          </span>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 text-balance">
+            Office Hours
+          </h2>
+          <div className="section-divider !bg-factory-green mt-3" />
+          <p className="text-gray-400 text-sm mt-4">
+            Click any block to see manager details &amp; contact info
+          </p>
         </div>
+
+        {/* Legend */}
+        <div className="flex items-center justify-center gap-4 mb-8">
+          <div className="flex items-center gap-1.5">
+            <div className="w-3 h-3 rounded-sm bg-factory-green/20 border border-factory-green/40" />
+            <span className="text-xs text-gray-400">1 hr session</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <div className="w-3 h-[18px] rounded-sm bg-factory-green/20 border border-factory-green/40" />
+            <span className="text-xs text-gray-400">1.5 hr session</span>
+          </div>
+        </div>
+
         <WeekView
           officeHours={officeHours}
           startTime={new Date(2021, 1, 1, 10, 30)}

--- a/frontend/src/components/WeekViewSection.tsx
+++ b/frontend/src/components/WeekViewSection.tsx
@@ -45,32 +45,20 @@ export function WeekViewSection(props: WeekViewSectionProps) {
   };
 
   return (
-    <section className="py-16 px-6 bg-gray-50 min-h-[600px]">
+    <section className="py-16 px-6 bg-factory-dark-black min-h-[600px]">
       <div className="max-w-5xl mx-auto">
         {/* Header */}
         <div className="text-center mb-10">
           <span className="inline-block text-factory-green text-xs font-bold uppercase tracking-widest mb-3">
             Lab Schedule
           </span>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 text-balance">
+          <h2 className="text-3xl md:text-4xl font-bold text-white text-balance">
             Office Hours
           </h2>
           <div className="section-divider !bg-factory-green mt-3" />
-          <p className="text-gray-400 text-sm mt-4">
+          <p className="text-white/40 text-sm mt-4">
             Click any block to see manager details &amp; contact info
           </p>
-        </div>
-
-        {/* Legend */}
-        <div className="flex items-center justify-center gap-4 mb-8">
-          <div className="flex items-center gap-1.5">
-            <div className="w-3 h-3 rounded-sm bg-factory-green/20 border border-factory-green/40" />
-            <span className="text-xs text-gray-400">1 hr session</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <div className="w-3 h-[18px] rounded-sm bg-factory-green/20 border border-factory-green/40" />
-            <span className="text-xs text-gray-400">1.5 hr session</span>
-          </div>
         </div>
 
         <WeekView


### PR DESCRIPTION
## Changes

### WeekView.tsx
- Both the main grid and the "not yet finalized" fallback grid are now wrapped in `overflow-x-auto` containers
- The inner `grid grid-cols-5` has `minWidth: 480px`, ensuring each day column is at least 96px wide and the grid never collapses below a readable size on phones
- `-mx-2 px-2` compensates for the scroll container edge so the content stays flush with the section padding